### PR TITLE
Fix empty PortInfo.description/hardware_id on Mac M1

### DIFF
--- a/src/impl/list_ports/list_ports_osx.cc
+++ b/src/impl/list_ports/list_ports_osx.cc
@@ -95,7 +95,7 @@ get_parent_iousb_device( io_object_t& serial_port )
     string name = get_class_name(device);
 
     // Walk the IO Registry tree looking for this devices parent IOUSBDevice.
-    while( name != "IOUSBDevice" )
+    while( name != "IOUSBDevice" && name != "IOUSBHostInterface" )
     {
         kern_result = IORegistryEntryGetParentEntry( device,
         kIOServicePlane,


### PR DESCRIPTION
on Mac M1, both PortInfo.description and PortInfo.hardware_id are "n/a", because usb device type name was changed from "IOUSBDevice" to "IOUSBHostInterface".